### PR TITLE
Add --no-prompt flag to avoid getting username and pass via prompt

### DIFF
--- a/nbconflux/api.py
+++ b/nbconflux/api.py
@@ -36,10 +36,6 @@ def notebook_to_page(notebook_file, confluence_url, username=None, password=None
     extra_labels: list, optional
         Additional labels to add to the page (default: None)
     """
-    if username is None:
-        username = getpass.getuser()
-    if password is None:
-        password = getpass.getpass('Confluence password for {}:'.format(username))
     if extra_labels is None:
         extra_labels = []
 

--- a/nbconflux/cli.py
+++ b/nbconflux/cli.py
@@ -17,6 +17,7 @@ def main(argv=None):
         "3. User prompts")
     parser.add_argument('notebook', type=str, help='Path to local notebook (ipynb)')
     parser.add_argument('url', type=str, help='URL of Confluence page to update')
+    parser.add_argument('--no-prompt', action='store_true', help='Do not prompt for password or username')
     parser.add_argument('--exclude-toc', action='store_true', help='Do not generate a table of contents')
     parser.add_argument('--exclude-ipynb', action='store_true', help='Do not attach the notebook to the page')
     parser.add_argument('--exclude-style', action='store_true', help='Do not include the Jupyter base stylesheet')
@@ -44,16 +45,17 @@ def main(argv=None):
                 password = segs[1]
                 print('Using credentials for {} from configuration file'.format(username))
 
-    # Prompt the user for missing credentials
-    if username is None:
-        current = getpass.getuser()
-        current = current[2:] if current.startswith('p-') else current
-        username = input('Confluence username ({}): '.format(current))
-        # Use the current username if the user doesn't enter anything
-        if not username.strip():
-            username = current
-    if password is None:
-        password = getpass.getpass('Confluence password: ')
+    if not args.no_prompt:
+        # Prompt the user for missing credentials
+        if username is None:
+            current = getpass.getuser()
+            current = current[2:] if current.startswith('p-') else current
+            username = input('Confluence username ({}): '.format(current))
+            # Use the current username if the user doesn't enter anything
+            if not username.strip():
+                username = current
+        if password is None:
+            password = getpass.getpass('Confluence password: ')
 
     notebook_to_page(args.notebook, args.url, username, password,
                      generate_toc=not args.exclude_toc, attach_ipynb=not args.exclude_ipynb,

--- a/nbconflux/exporter.py
+++ b/nbconflux/exporter.py
@@ -47,8 +47,8 @@ class ConfluenceExporter(HTMLExporter):
         Add MathJax to the page to render equations (default: False)
     """
     url = Unicode(config=True, help='Confluence URL to update with notebook content')
-    username = Unicode(config=True, help='Confluence username')
-    password = Unicode(config=True, help='Confluence password')
+    username = Unicode(config=True, allow_none=True, help='Confluence username')
+    password = Unicode(config=True ,allow_none=True, help='Confluence password')
     cookies = Dict(config=True, help='Confluence cookies')
     generate_toc = Bool(config=True, default_value=True, help='Show a table of contents at the top of the page?')
     attach_ipynb = Bool(config=True, default_value=True, help='Attach the notebook ipynb to the page?')
@@ -162,7 +162,7 @@ class ConfluenceExporter(HTMLExporter):
             resp = requests.get('{server}/rest/api/content?title={title}&spaceKey={space}'.format(server=server,
                                                                                                   title=title,
                                                                                                   space=space),
-                                auth=(self.username, self.password),
+                                auth=(self.username, self.password) if self.username and self.password else None,
                                 cookies=self.cookies
                                )
             resp.raise_for_status()
@@ -195,7 +195,7 @@ class ConfluenceExporter(HTMLExporter):
         # Fetch version number from the existing page so that we can increment it by 1.
         resp = requests.get('{server}/rest/api/content/{page_id}'.format(server=self.server,
                                                                          page_id=page_id),
-                            auth=(self.username, self.password),
+                            auth=(self.username, self.password) if self.username and self.password else None,
                             cookies=self.cookies
                             )
         resp.raise_for_status()
@@ -221,7 +221,7 @@ class ConfluenceExporter(HTMLExporter):
                                    }
                                }
                             },
-                            auth=(self.username, self.password),
+                            auth=(self.username, self.password) if self.username and self.password else None,
                             cookies=self.cookies
                            )
 
@@ -249,7 +249,7 @@ class ConfluenceExporter(HTMLExporter):
         resp = requests.post('{server}/rest/api/content/{page_id}/label'.format(server=self.server,
                                                                                 page_id=page_id),
                              json=[dict(prefix='global', name=label)],
-                             auth=(self.username, self.password),
+                             auth=(self.username, self.password) if self.username and self.password else None,
                              cookies=self.cookies
                              )
         resp.raise_for_status()
@@ -283,7 +283,7 @@ class ConfluenceExporter(HTMLExporter):
                                  'X-Atlassian-Token': 'nocheck'
                              },
                              files=files,
-                             auth=(self.username, self.password),
+                             auth=(self.username, self.password) if self.username and self.password else None,
                              cookies=self.cookies
                              )
         resp.raise_for_status()

--- a/nbconflux/preprocessor.py
+++ b/nbconflux/preprocessor.py
@@ -61,7 +61,7 @@ class ConfluencePreprocessor(Preprocessor):
         resources['attachments'] = {}
         while path:
             url = '{server}{path}'.format(server=self.exporter.server, path=path)
-            resp = requests.get(url, auth=(self.exporter.username, self.exporter.password), cookies=self.exporter.cookies)
+            resp = requests.get(url, auth=(self.exporter.username, self.exporter.password) if self.exporter.username and self.exporter.password else None, cookies=self.exporter.cookies)
             resp.raise_for_status()
             attachments = resp.json()
             # Build a map from attachment filename to attachment ID and attachment version


### PR DESCRIPTION
This allows cookies to work as a lone authorization method whereas
previously it was required that you entered a username and password
every time. Now it will simply attempt to load all three of username,
password and cookies from environment variables and use what it gets.
The gist of it is that any credentials of the 3 total provided through
environment variables or saved in config must be correct, but you are
only required to give either username and pass OR cookies.